### PR TITLE
Potential fix for code scanning alert no. 4: Insecure configuration of Helmet security middleware

### DIFF
--- a/guardiao/server.js
+++ b/guardiao/server.js
@@ -38,7 +38,7 @@ app.use(
 // Segurança de cabeçalhos; CSP com frame-ancestors controlando quem pode embutir o chat
 app.use(
   helmet({
-    frameguard: false, // preferimos controlar com CSP frame-ancestors
+    // frameguard enabled by default; CSP frame-ancestors also set below
     contentSecurityPolicy: {
       useDefaults: true,
       directives: {


### PR DESCRIPTION
Potential fix for [https://github.com/lichtara/site/security/code-scanning/4](https://github.com/lichtara/site/security/code-scanning/4)

To fix the issue and follow best practices, the configuration should enable Helmet's `frameguard` alongside the existing CSP `frame-ancestors` directive. This means removing (or setting to `true`) the `frameguard` field in the Helmet configuration on line 41. Let Helmet provide both the legacy `X-Frame-Options` header and the modern CSP header via your configuration.  

**Steps:**
- In `guardiao/server.js`, update the Helmet config block to remove `frameguard: false`, allowing it to use the default settings which enable frame protection with `X-Frame-Options`.
- No additional methods or imports needed, only the block in question must be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
